### PR TITLE
Raise error on fractional `R` values

### DIFF
--- a/R/bootES.R
+++ b/R/bootES.R
@@ -64,10 +64,22 @@ bootES <- function(data, R=2000, data.col=NULL, group.col=NULL, block.col=NULL,
     stop("'data' contains no records!")
   
   ## Checks on 'R'.
+  r.check.message = paste0(
+    "R must be of 'type' integer or 'type' real with no ",
+    "fractional or decimal parts")
+
+  # run this first to provide clear error messages to users
+  if (!is.numeric(R))
+    stop(r.check.message)
+
+  if (!isTRUE(all.equal(floor(R), R)))
+    stop(r.check.message)
+
   R = as.integer(R)
-  r.is.valid = (length(R) == 1) && is.numeric(R) && R > 0
+
+  r.is.valid = (length(R) == 1) && R >= 1
   if (!r.is.valid)
-    stop("R must be an integer of length 1 and greater than 0")
+    stop("R must be of length 1 and >= 1")
   
   ## Check and extract 'data.col'.
   if (!is.null(data.col)) {

--- a/tests/testthat/test_bootES.R
+++ b/tests/testthat/test_bootES.R
@@ -8,6 +8,23 @@ get_gender <- function() {
   gender
 }
 
+test_that("bootES handles invalid 'R' values", {
+  r_check_message = paste0(
+    "R must be of 'type' integer or 'type' real with no ",
+    "fractional or decimal parts")
+
+  ## Pass an 'R' with a fractional portion
+  res <- try(bootES(data.frame(scores=1), R=0.5), silent=TRUE)
+  expect_true(grepl(r_check_message, res))
+
+  ## Pass an 'R' with string
+  res <- try(bootES(data.frame(scores=1), R="5"), silent=TRUE)
+  expect_true(grepl(r_check_message, res))
+
+  ## Pass an 'R' with a negative value
+  res <- try(bootES(data.frame(scores=1), R=-1), silent=TRUE)
+  expect_true(grepl("R must be of length 1 and >= 1", res))
+})
 
 test_that("bootES handles invalid inputs", {
   gender = get_gender()
@@ -36,11 +53,7 @@ test_that("bootES handles invalid inputs", {
   
   ## Pass an 'R' of length greater than 1
   expect_error(bootES(data.frame(scores=1), R=c(2, 1)))
-  
-  ## Pass an 'R' with a fractional portion
-  res <- try(bootES(data.frame(scores=1), R=0.5), silent=TRUE)
-  expect_true(grepl("integer of length 1", res))
-  
+
   ## Use a 'data.col' not in 'data'
   expect_error(bootES(threeGps, R=250, data.col="foo"))
 


### PR DESCRIPTION
Previously, users could specify a fractional `R`, e.g., R=0.5, and bootES would take the floor of `R`, so 0.5 would become 0.

Now, users must provide, as `R`, an object of type real with no fractional or decimal part, or an integer.

Error messages have been improved to handle incorrect usage of `R`.

Resolves: 11